### PR TITLE
Use npyhz header and corresponding decoder to support uint16 image channels

### DIFF
--- a/src/neuroglancer/datasource/boss/backend.ts
+++ b/src/neuroglancer/datasource/boss/backend.ts
@@ -29,6 +29,8 @@ import {CancellationToken} from 'neuroglancer/util/cancellation';
 import {Endianness} from 'neuroglancer/util/endian';
 import {registerSharedObject, SharedObject} from 'neuroglancer/worker_rpc';
 
+// TODO (rodrilm): Add logic to use the jpeg header and decoder if the data is uint8 and use npygz if it is uint16
+// As of right now we will only use the npygz content type to ensure all types are supported.
 let chunkDecoders = new Map<string, ChunkDecoder>();
 chunkDecoders.set('npz', decodeBossNpzChunk);
 // chunkDecoders.set('jpeg', decodeJpegChunk);

--- a/src/neuroglancer/datasource/boss/backend.ts
+++ b/src/neuroglancer/datasource/boss/backend.ts
@@ -22,7 +22,7 @@ import {VolumeChunkSourceParameters, MeshSourceParameters} from 'neuroglancer/da
 import {VolumeChunkSource, VolumeChunk} from 'neuroglancer/sliceview/volume/backend';
 import {decodeJsonManifestChunk, decodeTriangleVertexPositionsAndIndices, FragmentChunk, ManifestChunk, MeshSource} from 'neuroglancer/mesh/backend';
 import {ChunkDecoder} from 'neuroglancer/sliceview/backend_chunk_decoders';
-import {decodeJpegChunk} from 'neuroglancer/sliceview/backend_chunk_decoders/jpeg';
+// import {decodeJpegChunk} from 'neuroglancer/sliceview/backend_chunk_decoders/jpeg';
 import {decodeBossNpzChunk} from 'neuroglancer/sliceview/backend_chunk_decoders/bossNpz';
 import {openShardedHttpRequest, sendHttpRequest} from 'neuroglancer/util/http_request';
 import {CancellationToken} from 'neuroglancer/util/cancellation';
@@ -31,11 +31,11 @@ import {registerSharedObject, SharedObject} from 'neuroglancer/worker_rpc';
 
 let chunkDecoders = new Map<string, ChunkDecoder>();
 chunkDecoders.set('npz', decodeBossNpzChunk);
-chunkDecoders.set('jpeg', decodeJpegChunk);
+// chunkDecoders.set('jpeg', decodeJpegChunk);
 
 let acceptHeaders = new Map<string, string>();
 acceptHeaders.set('npz', 'application/npygz');
-acceptHeaders.set('jpeg', 'image/jpeg');
+// acceptHeaders.set('jpeg', 'image/jpeg');
 
 function BossSource<Parameters, TBase extends {new (...args: any[]): SharedObject}>(
   Base: TBase, parametersConstructor: ChunkSourceParametersConstructor<Parameters>) {
@@ -66,9 +66,10 @@ export class BossVolumeChunkSource extends (BossSource(VolumeChunkSource, Volume
       path += `?window=${parameters.window[0]},${parameters.window[1]}`;
     }
 
+    // We will only use the npygz renderer provided by the boss server so that both uint16 and uint 8 are supported
     let acceptHeader: HttpHeader = {
         key: 'Accept',
-        value: acceptHeaders.get(parameters.encoding)!
+        value: 'application/npygz'
     }; 
     let httpCall: HttpCall = {
         method: 'GET',
@@ -77,7 +78,7 @@ export class BossVolumeChunkSource extends (BossSource(VolumeChunkSource, Volume
         headers: [acceptHeader]
     };
     return makeRequest(parameters.baseUrls, this.credentialsProvider, httpCall, cancellationToken)
-      .then(response => this.chunkDecoder(chunk, response));
+      .then(response => decodeBossNpzChunk(chunk, response));
   }
 };
 

--- a/src/neuroglancer/datasource/boss/frontend.ts
+++ b/src/neuroglancer/datasource/boss/frontend.ts
@@ -193,10 +193,10 @@ function parseExperimentInfo(
 
 export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunkSource {
   get dataType() {
-    if (this.channelInfo.dataType === DataType.UINT16) {
-      // 16-bit channels automatically rescaled to uint8 by The Boss
-      return DataType.UINT16;
-    }
+    // if (this.channelInfo.dataType === DataType.UINT16) {
+    //   16-bit channels automatically rescaled to uint8 by The Boss
+    //   return DataType.UINT16;
+    // }
     return this.channelInfo.dataType;
   }
   get numChannels() {

--- a/src/neuroglancer/datasource/boss/frontend.ts
+++ b/src/neuroglancer/datasource/boss/frontend.ts
@@ -195,7 +195,7 @@ export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunk
   get dataType() {
     if (this.channelInfo.dataType === DataType.UINT16) {
       // 16-bit channels automatically rescaled to uint8 by The Boss
-      return DataType.UINT8;
+      return DataType.UINT16;
     }
     return this.channelInfo.dataType;
   }


### PR DESCRIPTION
It seems like neuroglancer is currently failing to use the npygz header over the jpeg header during content management when the latter fails. This causes a 400 HTTP Error to appear and uint16 channels are not correctly displayed on the site's frontend. 

Since the content type application/npygz is functional for both uint8 and uint16 and the image/jpeg header is only compatible with uint8 data, this update only makes use of the npygz content type. 
In future updates some logic should be included to use on or the other depending on the channels data type. 