### PR TITLE
Try to access public endpoints before asking for auth

### DIFF
--- a/src/neuroglancer/datasource/boss/api.ts
+++ b/src/neuroglancer/datasource/boss/api.ts
@@ -27,10 +27,14 @@ export type BossToken = string;
 export const credentialsKey = 'boss';
 
 export function fetchWithBossCredentials<T>(
-    credentialsProvider: CredentialsProvider<BossToken>, input: RequestInfo, init: RequestInit,
-    transformResponse: ResponseTransform<T>,
-    cancellationToken: CancellationToken = uncancelableToken): Promise<T> {
-  return fetchWithCredentials(
+  credentialsProvider: CredentialsProvider<BossToken>, input: RequestInfo, init: RequestInit,
+  transformResponse: ResponseTransform<T>,
+  cancellationToken: CancellationToken = uncancelableToken): Promise<T> {
+  try {
+    return cancellableFetchOk(input, init, transformResponse, cancellationToken)
+  } catch (error) {
+    console.error(error)
+    return fetchWithCredentials(
       credentialsProvider, input, init, transformResponse,
       credentials => {
         const headers = new Headers(init.headers);
@@ -50,4 +54,5 @@ export function fetchWithBossCredentials<T>(
         throw error;
       },
       cancellationToken);
+  }
 }

--- a/src/neuroglancer/datasource/boss/api.ts
+++ b/src/neuroglancer/datasource/boss/api.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { CredentialsProvider } from 'neuroglancer/credentials_provider';
-import { fetchWithCredentials } from 'neuroglancer/credentials_provider/http_request';
-import { CancellationToken, uncancelableToken } from 'neuroglancer/util/cancellation';
-import { cancellableFetchOk } from 'neuroglancer/util/http_request';
-import { ResponseTransform } from 'neuroglancer/util/http_request';
+import {CredentialsProvider} from 'neuroglancer/credentials_provider';
+import {fetchWithCredentials} from 'neuroglancer/credentials_provider/http_request';
+import {CancellationToken, uncancelableToken} from 'neuroglancer/util/cancellation';
+import {cancellableFetchOk} from 'neuroglancer/util/http_request';
+import {ResponseTransform} from 'neuroglancer/util/http_request';
 
 export type BossToken = string;
 
@@ -42,10 +42,10 @@ export function fetchWithBossCredentials<T>(
       credentials => {
         const headers = new Headers(init.headers);
         headers.set('Authorization', `Bearer ${credentials}`);
-        return { ...init, headers };
+        return {...init, headers};
       },
       error => {
-        const { status } = error;
+        const {status} = error;
         if (status === 403 || status === 401) {
           // Authorization needed.  Retry with refreshed token.
           return 'refresh';

--- a/src/neuroglancer/datasource/boss/api.ts
+++ b/src/neuroglancer/datasource/boss/api.ts
@@ -17,8 +17,7 @@
 import {CredentialsProvider} from 'neuroglancer/credentials_provider';
 import {fetchWithCredentials} from 'neuroglancer/credentials_provider/http_request';
 import {CancellationToken, uncancelableToken} from 'neuroglancer/util/cancellation';
-import {cancellableFetchOk} from 'neuroglancer/util/http_request';
-import {ResponseTransform} from 'neuroglancer/util/http_request';
+import {ResponseTransform, cancellableFetchOk} from 'neuroglancer/util/http_request';
 
 export type BossToken = string;
 

--- a/src/neuroglancer/datasource/boss/api.ts
+++ b/src/neuroglancer/datasource/boss/api.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import {CredentialsProvider} from 'neuroglancer/credentials_provider';
-import {fetchWithCredentials} from 'neuroglancer/credentials_provider/http_request';
-import {CancellationToken, uncancelableToken} from 'neuroglancer/util/cancellation';
-import {cancellableFetchOk} from 'neuroglancer/util/http_request';
-import {ResponseTransform} from 'neuroglancer/util/http_request';
+import { CredentialsProvider } from 'neuroglancer/credentials_provider';
+import { fetchWithCredentials } from 'neuroglancer/credentials_provider/http_request';
+import { CancellationToken, uncancelableToken } from 'neuroglancer/util/cancellation';
+import { cancellableFetchOk } from 'neuroglancer/util/http_request';
+import { ResponseTransform } from 'neuroglancer/util/http_request';
 
 export type BossToken = string;
 
@@ -32,12 +32,8 @@ export function fetchWithBossCredentials<T>(
   transformResponse: ResponseTransform<T>,
   cancellationToken: CancellationToken = uncancelableToken): Promise<T> {
   return cancellableFetchOk(input, init, transformResponse, cancellationToken).catch((error) => {
-    // if (error.status === 504) {
-    //   // Gateway timeout can occur if the server takes too long to reply.  Retry.
-    //   return 'retry';
-    // }
-    if (error.status < 100) {
-      // Prevent an infinite loop of error = 0 where the request 
+    if (error.status !== 500 && error.status !== 401 && error.status !== 403 && error.status !== 504) {
+      // Prevent an infinite loop of error = 0 where the request
       // has been cancelled
       throw error;
     }
@@ -46,10 +42,10 @@ export function fetchWithBossCredentials<T>(
       credentials => {
         const headers = new Headers(init.headers);
         headers.set('Authorization', `Bearer ${credentials}`);
-        return {...init, headers};
+        return { ...init, headers };
       },
       error => {
-        const {status} = error;
+        const { status } = error;
         if (status === 403 || status === 401) {
           // Authorization needed.  Retry with refreshed token.
           return 'refresh';

--- a/src/neuroglancer/datasource/boss/api.ts
+++ b/src/neuroglancer/datasource/boss/api.ts
@@ -17,6 +17,7 @@
 import {CredentialsProvider} from 'neuroglancer/credentials_provider';
 import {fetchWithCredentials} from 'neuroglancer/credentials_provider/http_request';
 import {CancellationToken, uncancelableToken} from 'neuroglancer/util/cancellation';
+import {cancellableFetchOk} from 'neuroglancer/util/http_request';
 import {ResponseTransform} from 'neuroglancer/util/http_request';
 
 export type BossToken = string;


### PR DESCRIPTION
- [x] Fail on private data without auth
- [x] Ask for auth on private data
- [x] Don't ask for auth on public data

We still ask for auth even if the user has started downloading data... Is there an endpoint we're missing?