### PR TITLE
Adding python deploy to github action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,10 @@ jobs:
       run: npm run typecheck
     - name: Build client bundles
       run: npm run build --no-typecheck
+    - name: Build client python bundles
+      run: npm run build-python
+    - name: Copy python bundle into new folder
+      run: cp -r python/neuroglancer/static python
     - name: S3 Sync
       uses: jakejarvis/s3-sync-action@v0.5.0
       with:


### PR DESCRIPTION
Teeny merge request to adjust the way we deploy to production Neuroglancer. It will include the version of Neuroglancer with the python integration at `/python`.

I tested this by creating a new S3 bucket, located here: http://neuroglancer-dev.s3-website-us-east-1.amazonaws.com/. It is currently set so that the general public can hit the URL, so if we leave it up, let me know if there should be tighter permissions.

For you to test this MR:
* Make sure it works with the Python API by [following the instructions in the wiki](https://github.com/aplbrain/wiki/blob/master/projects/neuroglancer/pythonAPI.md). 
* Use the remote server option 
* Replace the Google default URL with our new one: http://neuroglancer-dev.s3-website-us-east-1.amazonaws.com/python
* Try some of the commands in the wiki page

Once this is merged in, we will be able to use https://neuroglancer.bossdb.io/python instead.

Once I made the S3 bucket, I forked the repo, linked its secrets to my fork, and tested the action. Here are the logs showing that it succeeded: https://github.com/hannahgooden/neuroglancer/runs/2412948419?check_suite_focus=true

Feel free to message me with any questions!